### PR TITLE
fix: adding in language preference of participate to instructions

### DIFF
--- a/mastra-test-app/src/mastra/agents/web-automation-agent.ts
+++ b/mastra-test-app/src/mastra/agents/web-automation-agent.ts
@@ -1,12 +1,12 @@
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
+import { exaMCP, playwrightMCP } from '../mcp';
 
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
-import { playwrightMCP, exaMCP } from '../mcp';
-import { openai } from '@ai-sdk/openai';
 import { anthropic } from '@ai-sdk/anthropic';
-import { google } from '@ai-sdk/google';
 import { databaseTools } from '../tools/database-tools';
+import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
 
 const base = process.env.DB_BASE || "../";
 // Path is relative to .mastra/output/ when bundled
@@ -70,6 +70,7 @@ export const webAutomationAgent = new Agent({
     **When given database participant information:**
     - Immediately use the data to populate web forms
     - Navigate to the appropriate website (research if URL unknown)
+    - If the participant has a preferred language, change the website language to match it
     - Fill all available fields with the participant data
     - Proceed through the application process autonomously
 
@@ -81,6 +82,8 @@ export const webAutomationAgent = new Agent({
 
     **Web Navigation:**
     - Navigate to websites and analyze page structure
+    - If participant has a preferred language, immediately look for and change the website language
+    - Common language selectors: language dropdowns, flag icons, "EN" buttons, or language preference settings
     - Identify and interact with elements (buttons, forms, links, dropdowns)
 
     When performing actions:


### PR DESCRIPTION
## Ticket

Resolves part of [ASP-99](https://navalabs.atlassian.net/browse/ASP-99)

## Changes

Added to the instructions of the AI bot for looking at the preferred language of the participant and using that to change the website's language content

## Context for reviewers

The case worker may prefer to view in English (for the bot) while the participant would rather view the website in Spanish