### PR TITLE
`refactor: suggested changes to languagePreference scorer steps and organization

### DIFF
--- a/mastra-test-app/src/mastra/agents/web-automation-agent.ts
+++ b/mastra-test-app/src/mastra/agents/web-automation-agent.ts
@@ -81,7 +81,7 @@ export const webAutomationAgent = new Agent({
     **Web Navigation:**
     - Navigate to websites and analyze page structure
     - If participant has a preferred language, immediately look for and change the website language
-    - Common language selectors: language dropdowns, flag icons, "EN" buttons, or language preference settings
+    - Common language selectors: "Select Language" dropdowns, flag icons, buttons that say "EN" or "SP", or language preference settings
     - Identify and interact with elements (buttons, forms, links, dropdowns)
 
     When performing actions:

--- a/mastra-test-app/src/mastra/scorers/languagePreference/index.ts
+++ b/mastra-test-app/src/mastra/scorers/languagePreference/index.ts
@@ -1,4 +1,4 @@
-import { LANGUAGE_PREFERENCE_PROMPT, generateReasonPrompt, languagePreferenceCheckPrompt } from './prompt';
+import { LANGUAGE_PREFERENCE_PROMPT, createPreprocessPrompt, createAnalysisPrompt, createReasonPrompt } from './prompt';
 
 import { LanguageModel } from '@mastra/core';
 import { createScorer } from '@mastra/core/scores';
@@ -17,43 +17,75 @@ export function createLanguagePreferenceScorer({
       instructions: LANGUAGE_PREFERENCE_PROMPT
     }
   })
-  .analyze({
-    description: 'Analyze the output for language preference',
+  .preprocess({
+    description: 'Extract language preferences and actions from the conversation',
     outputSchema: z.object({
-      language: z.string(),
-      confidence: z.number(),
+      participantLanguage: z.string().nullable(),
+      languageChangeActions: z.array(z.string()),
+      websiteLanguageSet: z.boolean(),
+      targetLanguage: z.string().nullable()
     }),
     createPrompt: ({ run }) => {
-      const { output } = run;
-      return languagePreferenceCheckPrompt({ output: output.text });
+      // For web automation agent, the output contains the agent's actions and reasoning
+      const agentOutput = Array.isArray(run.output) ? 
+        run.output.map(msg => msg.content).join('\n') : 
+        run.output?.text || run.output || '';
+      
+      const userInput = Array.isArray(run.input) ? 
+        run.input.map(msg => msg.content).join('\n') : 
+        run.input?.text || run.input || '';
+
+      return createPreprocessPrompt({ userInput, agentOutput });
+    },
+  })
+  .analyze({
+    description: 'Evaluate language preference compliance',
+    outputSchema: z.object({
+      compliance: z.enum(['excellent', 'good', 'partial', 'poor', 'no_preference']),
+      languageMatch: z.boolean(),
+      actionsTaken: z.boolean(),
+      confidence: z.number().min(0).max(1),
+    }),
+    createPrompt: ({ run, results }) => {
+      const { participantLanguage, languageChangeActions, websiteLanguageSet, targetLanguage } = results.preprocessStepResult;
+      
+      return createAnalysisPrompt({
+        participantLanguage,
+        languageChangeActions,
+        websiteLanguageSet,
+        targetLanguage
+      });
     },
   })
   .generateScore(({ results }) => {
-    return results.analyzeStepResult.confidence;
+    const { compliance, confidence } = results.analyzeStepResult;
+    
+    // Convert compliance level to numerical score
+    const complianceScores = {
+      'excellent': 1.0,
+      'good': 0.8,
+      'partial': 0.5,
+      'poor': 0.2,
+      'no_preference': 1.0 // No penalty if no preference was specified
+    };
+    
+    const baseScore = complianceScores[compliance] || 0;
+    return baseScore * confidence;
   })
   .generateReason({
-    description: 'Generate a reason for the score',
-    createPrompt: ({ results }) => {
-      return generateReasonPrompt({
-        language: results.analyzeStepResult.language,
-        confidence: results.analyzeStepResult.confidence,
+    description: 'Generate a reason for the language preference compliance score',
+    createPrompt: ({ results, score }) => {
+      const { compliance, languageMatch, actionsTaken } = results.analyzeStepResult;
+      const { participantLanguage, targetLanguage } = results.preprocessStepResult;
+      
+      return createReasonPrompt({
+        score,
+        compliance,
+        languageMatch,
+        actionsTaken,
+        participantLanguage,
+        targetLanguage
       });
     },
-})
-}
-
-// work in progress
-function getComplianceReason(level: string, language?: string): string {
-  switch (level) {
-    case 'excellent':
-      return `Successfully changed website language to ${language || 'participant preference'}`;
-    case 'partial':
-      return `Detected language change actions but may not have set the preferred language (${language})`;
-    case 'poor':
-      return `Failed to change website language to ${language || 'participant preference'}`;
-    case 'no_preference':
-      return 'No language preference specified by participant';
-    default:
-      return 'Language preference compliance could not be determined';
-  }
+  });
 }

--- a/mastra-test-app/src/mastra/scorers/languagePreference/prompt.ts
+++ b/mastra-test-app/src/mastra/scorers/languagePreference/prompt.ts
@@ -1,46 +1,92 @@
 export const LANGUAGE_PREFERENCE_PROMPT = `You are an expert language accessibility auditor who evaluates if web automation agents properly set website language preferences for participants.
 
-Key Principles:
+Key Evaluation Principles:
 
-1. The agent should set the website language to the participant's preferred language.
-2. The agent does not need to switch to the participant's preferred language if it is not available on the website.
-3. Before performing an action, the language should be set to the participant's preferred language.
-`
+1. **Language Identification**: The agent should correctly identify when a participant has a language preference different from English.
 
-export const languagePreferenceCheckPrompt = ({output}: {output: string}) => `See if the following output contains a language preference.
-Check for:
-- User stating they like to speak in a different language
-- User stating they like to use a different language
-- User stating English is not their first language
-- User states that they have a client who speaks a different language
+2. **Proactive Language Setting**: The agent should change the website language to match the participant's preference BEFORE filling out forms or performing other actions.
 
-Example for English:
-"I speak English."
+3. **Language Availability**: The agent should attempt to change the language but is not penalized if the preferred language is not available on the website.
 
-Response: {
-    "language": "English",
-    "confidence": 0.95
-}
+4. **Documentation**: The agent should clearly document what language changes were attempted and whether they were successful.
 
-Example for Spanish:
-"I speak Spanish."
-Response: {
-    "language": "Spanish",
-    "confidence": 0.95
-}
+5. **User Experience**: Priority should be given to ensuring the participant can understand the website content in their preferred language.
 
-Message to analyze:
-${output}
+Common Language Indicators:
+- Direct statements: "I speak Spanish", "My preferred language is French"
+- Indirect indicators: "English is not my first language", "I need help in Chinese"
+- Third-party references: "My client speaks Vietnamese", "The applicant prefers Korean"
+- Cultural context: Mentions of specific cultural backgrounds that suggest language preferences
 
-Return the response in JSON format.
-`
-export const generateReasonPrompt = ({
-    language,
-    confidence,
-  }: {
-    language: string;
-    confidence: number;
-  }) => `Explain why the language is ${language} with a confidence of ${confidence}.
-   
-  Return your response in this format:
-  "The language is ${language} with a confidence of ${confidence} because [explanation]"`;
+Evaluation should focus on whether the agent took appropriate action based on the language preference signals in the conversation.`
+
+// Preprocess step prompt
+export const createPreprocessPrompt = ({ userInput, agentOutput }: { userInput: string; agentOutput: string }) => `
+Analyze this web automation conversation for language preferences and actions:
+
+User Input: ${userInput}
+Agent Output: ${agentOutput}
+
+Extract:
+1. What language does the participant prefer (if mentioned)?
+2. What language change actions did the agent take?
+3. Did the agent successfully set the website language?
+4. What language was the website set to?
+
+Return JSON with participantLanguage, languageChangeActions array, websiteLanguageSet boolean, and targetLanguage.
+`;
+
+// Analysis step prompt  
+export const createAnalysisPrompt = ({ 
+  participantLanguage, 
+  languageChangeActions, 
+  websiteLanguageSet, 
+  targetLanguage 
+}: {
+  participantLanguage: string | null;
+  languageChangeActions: string[];
+  websiteLanguageSet: boolean;
+  targetLanguage: string | null;
+}) => `
+Evaluate language preference compliance based on this analysis:
+
+Participant Language Preference: ${participantLanguage || 'None specified'}
+Language Change Actions: ${languageChangeActions.join(', ') || 'None'}
+Website Language Set: ${websiteLanguageSet}
+Target Language: ${targetLanguage || 'Not specified'}
+
+Scoring criteria:
+- "excellent": Agent identified participant language preference and successfully changed website language to match
+- "good": Agent attempted to change language and mostly succeeded 
+- "partial": Agent recognized language preference but didn't fully implement the change
+- "poor": Agent failed to change language despite clear preference
+- "no_preference": No language preference was specified by participant
+
+Return JSON with compliance level, languageMatch boolean, actionsTaken boolean, and confidence (0-1).
+`;
+
+// Reason generation step prompt
+export const createReasonPrompt = ({ 
+  score, 
+  compliance, 
+  languageMatch, 
+  actionsTaken, 
+  participantLanguage, 
+  targetLanguage 
+}: {
+  score: number;
+  compliance: string;
+  languageMatch: boolean;
+  actionsTaken: boolean;
+  participantLanguage: string | null;
+  targetLanguage: string | null;
+}) => `
+Explain the language preference compliance score of ${score} based on:
+- Compliance Level: ${compliance}
+- Participant Language: ${participantLanguage || 'Not specified'}
+- Target Language Set: ${targetLanguage || 'Not set'}
+- Language Match: ${languageMatch}
+- Actions Taken: ${actionsTaken}
+
+Provide a clear explanation of why this score was assigned and what the agent did well or could improve.
+`;


### PR DESCRIPTION
## Description
Only intended to be suggestions, please choose to merge/reject any part 

## Suggestions

- **src/mastra/scorers/languagePreference/index.ts**: uses full 4-step [evaluation pipeline](https://mastra.ai/en/docs/scorers/overview#evaluation-pipeline) (preprocess, analyze, generateScore, generateReason) with compliance level and confidence weights as structured outputs
- **src/mastra/scorers/languagePreference/prompt.ts**: cetnralizes prompts as Zod typed functions